### PR TITLE
[CS2113-T13-1]-Lucria-AddJacocoTestCoverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - ./gradlew clean checkstyleMain checkstyleTest test
 
 after_success:
-  - ./gradlew coverage coveralls
+  - ./gradlew jacocoTestReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ jdk: oraclejdk11
 
 before_install:
   - chmod +x gradlew
+
+after_success:
+  - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ jdk: oraclejdk11
 before_install:
   - chmod +x gradlew
 
+script:
+  - ./gradlew clean checkstyleMain checkstyleTest test
+
 after_success:
   - ./gradlew coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
   - chmod +x gradlew
 
 after_success:
-  - ./gradlew jacocoTestReport coveralls
+  - ./gradlew coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
   - chmod +x gradlew
 
 after_success:
-  - mvn clean test jacoco:report coveralls:report
+  - ./gradlew jacocoTestReport coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -40,21 +40,19 @@ task coverage(type: JacocoReport) {
             fileTree(dir: it, exclude: ['**/*.jar'])
         })
     }
-}
-
-tasks.coveralls {
-    dependsOn coverage
-    onlyIf { System.env.'CI' }
+    reports {
+        html.enabled = true
+        xml.enabled = true
+    }
 }
 
 coveralls {
     jacocoReportPath "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
 }
 
-dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.5.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'org.eluder.coveralls:coveralls-maven-plugin:4.3.0'
+tasks.coveralls {
+    dependsOn coverage
+    onlyIf { System.env.'CI' }
 }
 
 test {
@@ -92,6 +90,9 @@ javafx {
 
 dependencies {
     String javaFxVersion = '11'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.5.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'checkstyle'
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id 'org.openjfx.javafxplugin' version '0.0.7'
+    id 'jacoco'
 }
 
 checkstyle {
@@ -17,9 +18,23 @@ shadowJar {
     archiveAppendix = null
 }
 
+jacoco {
+    toolVersion = "0.8.4"
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination file("${buildDir}/jacocoHtml")
+    }
+}
+
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'org.eluder.coveralls:coveralls-maven-plugin:4.3.0'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ test {
 }
 
 group 'seedu.duke'
-version '0.1.2'
+version '0.1.3'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -27,33 +27,11 @@ jacocoTestReport {
     reports {
         xml.enabled true
         csv.enabled true
-        html.destination file("${buildDir}/jacocoHtml")
-    }
-}
-
-task coverage(type: JacocoReport) {
-    sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
-    classDirectories.from files(sourceSets.main.output)
-    executionData.from files(jacocoTestReport.executionData)
-    afterEvaluate {
-        classDirectories.from files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/*.jar'])
-        })
-    }
-    reports {
-        html.enabled = true
-        xml.enabled = true
     }
 }
 
 coveralls {
-    sourceDirs = sourceSets.main.allSource.srcDirs.absolutePath
-    jacocoReportPath = "${buildDir}/reports/jacoco/coverage/coverage.xml"
-}
-
-tasks.coveralls {
-    dependsOn coverage
-    onlyIf { System.env.'CI' }
+    jacocoReportPath 'build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ task coverage(type: JacocoReport) {
 }
 
 coveralls {
-    jacocoReportPath "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    sourceDirs = sourceSets.main.allSource.srcDirs.absolutePath
+    jacocoReportPath = "${buildDir}/reports/jacoco/coverage/coverage.xml"
 }
 
 tasks.coveralls {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ checkstyle {
 
 shadowJar {
     archiveBaseName = "duke"
-    archiveVersion = "0.1.2"
+    archiveVersion = "0.1.3"
     archiveClassifier = null
     archiveAppendix = null
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id 'org.openjfx.javafxplugin' version '0.0.7'
     id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.8.4'
 }
 
 checkstyle {
@@ -20,15 +21,34 @@ shadowJar {
 
 jacoco {
     toolVersion = "0.8.4"
-    reportsDir = file("$buildDir/customJacocoReportDir")
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled false
-        csv.enabled false
+        xml.enabled true
+        csv.enabled true
         html.destination file("${buildDir}/jacocoHtml")
     }
+}
+
+task coverage(type: JacocoReport) {
+    sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
+    classDirectories.from files(sourceSets.main.output)
+    executionData.from files(jacocoTestReport.executionData)
+    afterEvaluate {
+        classDirectories.from files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['**/*.jar'])
+        })
+    }
+}
+
+tasks.coveralls {
+    dependsOn coverage
+    onlyIf { System.env.'CI' }
+}
+
+coveralls {
+    jacocoReportPath "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
 }
 
 dependencies {
@@ -39,6 +59,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    jacoco {
+        destinationFile = new File("${buildDir}/jacoco/test.exec")
+    }
 }
 
 group 'seedu.duke'


### PR DESCRIPTION
Adding Jacoco test coverage plugin to Gradle and integrating it with Travis CI and Coveralls such that test coverage report can be generated automatically and reported to us.