### PR TITLE
[CS2113-T13-1]-seanlimhx-FixedBugsForEditTaskAndEditTaskRequirements

### DIFF
--- a/src/main/java/controllers/ProjectInputController.java
+++ b/src/main/java/controllers/ProjectInputController.java
@@ -337,15 +337,14 @@ public class ProjectInputController implements IController {
             String updatedTaskDetails = projectCommand.substring(projectCommand.indexOf("-"));
 
             if (projectToManage.getNumOfTasks() >= taskIndexNumber && taskIndexNumber > 0) {
-                projectToManage.editTask(taskIndexNumber, updatedTaskDetails);
-                return new String[] { "The task has been updated!" };
+                return projectToManage.editTask(taskIndexNumber, updatedTaskDetails);
             }
             return new String[] {"The task index entered is invalid."};
 
         } catch (NumberFormatException e) {
             ArchDukeLogger.logError(ProjectInputController.class.getName(), "[projectEditTask] "
-                    + "Please enter your task format correctly.");
-            return new String[] {"Please enter your task format correctly."};
+                    + "Please enter a valid number for your task index.");
+            return new String[] {"Please enter a valid number for your task index."};
         }
     }
 

--- a/src/main/java/controllers/ProjectInputController.java
+++ b/src/main/java/controllers/ProjectInputController.java
@@ -332,11 +332,14 @@ public class ProjectInputController implements IController {
                 return new String[]
                 {"No parameters detected. Please enter details in the following format:",
                  "TASK_INDEX [-t TASK_NAME] [-p TASK_PRIORITY] [-d TASK_DUEDATE] [-c TASK_CREDIT] [-s STATE]"};
-            }
-            int taskIndexNumber = Integer.parseInt(projectCommand.substring(10).split(" ")[0]);
-            String updatedTaskDetails = projectCommand.substring(projectCommand.indexOf("-"));
-
+            } 
+            int taskIndexNumber = Integer.parseInt(projectCommand.substring(10).trim().split(" ")[0]);
             if (projectToManage.getNumOfTasks() >= taskIndexNumber && taskIndexNumber > 0) {
+                if (!projectCommand.contains("-")) {
+                    return new String[] {"No flags are found! Available flags for use are '-t', '-p, '-d', '-c' and "
+                            + "'-s' to indicate the new task details! Refer to the user guide for more help!"};
+                }
+                String updatedTaskDetails = projectCommand.substring(projectCommand.indexOf("-"));
                 return projectToManage.editTask(taskIndexNumber, updatedTaskDetails);
             }
             return new String[] {"The task index entered is invalid."};

--- a/src/main/java/models/project/IProject.java
+++ b/src/main/java/models/project/IProject.java
@@ -32,7 +32,7 @@ public interface IProject {
 
     Task getTask(int taskIndex);
 
-    void editTask(int taskIndexNumber, String updatedTaskDetails);
+    String[] editTask(int taskIndexNumber, String updatedTaskDetails);
 
     String[] editTaskRequirements(int taskIndexNumber, String updatedTaskRequirements);
 

--- a/src/main/java/models/project/NullProject.java
+++ b/src/main/java/models/project/NullProject.java
@@ -80,10 +80,11 @@ public class NullProject implements IProject {
     }
 
     @Override
-    public void editTask(int taskIndexNumber, String updatedTaskDetails) {
+    public String[] editTask(int taskIndexNumber, String updatedTaskDetails) {
         /*
         Empty method
          */
+        return new String[0];
     }
 
     @Override

--- a/src/main/java/models/project/Project.java
+++ b/src/main/java/models/project/Project.java
@@ -104,8 +104,8 @@ public class Project implements IProject {
     }
 
     @Override
-    public void editTask(int taskIndexNumber, String updatedTaskDetails) {
-        this.taskList.editTask(taskIndexNumber, updatedTaskDetails);
+    public String[] editTask(int taskIndexNumber, String updatedTaskDetails) {
+        return this.taskList.editTask(taskIndexNumber, updatedTaskDetails);
     }
 
     @Override

--- a/src/main/java/models/task/ITask.java
+++ b/src/main/java/models/task/ITask.java
@@ -24,7 +24,7 @@ public interface ITask {
 
     void setTaskPriority(int newTaskPriority);
 
-    void setDueDate(String newDueDateString);
+    void setDueDate(Date newDueDate);
 
     void setTaskCredit(int newTaskCredit);
 

--- a/src/main/java/models/task/NullTask.java
+++ b/src/main/java/models/task/NullTask.java
@@ -59,7 +59,7 @@ public class NullTask implements ITask {
     }
 
     @Override
-    public void setDueDate(String newDueDateString) {
+    public void setDueDate(Date newDueDate) {
         /**
          * Empty method
          */

--- a/src/main/java/models/task/Task.java
+++ b/src/main/java/models/task/Task.java
@@ -1,6 +1,5 @@
 package models.task;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Objects;
@@ -120,15 +119,11 @@ public class Task implements ITask {
     }
 
     /**
-     * Converts String input into Date object to be set as the new dueDate.
-     * @param newDueDateString String form of the new dueDate to be set.
+     * Set input Date object as the new dueDate.
+     * @param newDueDate Date object of the new dueDate to be set.
      */
-    public void setDueDate(String newDueDateString) {
-        try {
-            this.dueDate = dateTimeHelper.formatDate(newDueDateString);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
+    public void setDueDate(Date newDueDate) {
+        this.dueDate = newDueDate;
     }
 
     /**
@@ -144,8 +139,7 @@ public class Task implements ITask {
      * @param newTaskStateString String form of new task state.
      */
     public void setTaskState(String newTaskStateString) {
-        String newTaskStateLowerCase = newTaskStateString.toLowerCase();
-        switch (newTaskStateLowerCase) {
+        switch (newTaskStateString) {
         case "done":
             this.taskState = TaskState.DONE;
             break;

--- a/src/main/java/models/task/TaskList.java
+++ b/src/main/java/models/task/TaskList.java
@@ -123,7 +123,7 @@ public class TaskList {
         String taskName = taskDetails.get(0);
         ArrayList<String> messagesForUser = new ArrayList<>();
         ArrayList<String> successMessages = new ArrayList<>();
-        ArrayList<String> errorMessages = new ArrayList<>();
+        ArrayList<String> errorMessages = new ArrayList<>(parserHelper.getErrorMessages());
 
         Task task = taskList.get(taskIndexNumber - 1);
         if (!("--".equals(taskName))) {

--- a/src/main/java/models/task/TaskList.java
+++ b/src/main/java/models/task/TaskList.java
@@ -8,6 +8,7 @@ import util.date.DateTimeHelper;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 
 public class TaskList {
@@ -147,7 +148,10 @@ public class TaskList {
         String taskDueDate = taskDetails.get(2);
         if (taskDueDate != null) {
             try {
-                task.setDueDate(dateTimeHelper.formatDate(taskDueDate));
+                Date newDueDate = dateTimeHelper.formatDate(taskDueDate);
+                task.setDueDate(newDueDate);
+                successMessages.add("The new due date for this task has been set to "
+                        + dateTimeHelper.formatDateForDisplay(newDueDate) + "!");
             } catch (ParseException e) {
                 errorMessages.add("Input for new task due date is invalid! Please input the date in the "
                         + "form 'dd/mm/yyyy'.");

--- a/src/main/java/models/task/TaskList.java
+++ b/src/main/java/models/task/TaskList.java
@@ -3,7 +3,9 @@ package models.task;
 import models.member.Member;
 import util.ParserHelper;
 import util.SortHelper;
+import util.date.DateTimeHelper;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -12,6 +14,7 @@ public class TaskList {
     private ArrayList<Task> taskList;
     private ParserHelper parserHelper;
     private SortHelper sortHelper;
+    private DateTimeHelper dateTimeHelper;
 
     /**
      * Class representing a list with all task sort in the project.
@@ -20,6 +23,7 @@ public class TaskList {
         this.taskList = new ArrayList<>();
         this.parserHelper = new ParserHelper();
         this.sortHelper = new SortHelper();
+        this.dateTimeHelper = new DateTimeHelper();
     }
 
     /**
@@ -108,34 +112,89 @@ public class TaskList {
 
     /**
      * Edits details of a task excluding task requirements.
+     * @param taskIndexNumber Index of task to be edited
      * @param updatedTaskDetails input command String in the form of (tasks to be edited can be in any order)
      *                           edit task i/TASK_INDEX [n/TASK_NAME] [p/TASK_PRIORITY]
      *                           [d/TASK_DUEDATE] [c/TASK_CREDIT] [s/STATE]
+     * @return String array containing messages to the user to be printed.
      */
-    public void editTask(int taskIndexNumber, String updatedTaskDetails) {
+    public String[] editTask(int taskIndexNumber, String updatedTaskDetails) {
         ArrayList<String> taskDetails = parserHelper.parseTaskDetails(updatedTaskDetails);
         String taskName = taskDetails.get(0);
+        ArrayList<String> messagesForUser = new ArrayList<>();
+        ArrayList<String> successMessages = new ArrayList<>();
+        ArrayList<String> errorMessages = new ArrayList<>();
 
         Task task = taskList.get(taskIndexNumber - 1);
         if (!("--".equals(taskName))) {
             task.setTaskName(taskName);
+            successMessages.add("The name of this task has been changed to '" + taskName + "'!");
         }
         String taskPriority = taskDetails.get(1);
         if (!("-1".equals(taskPriority))) {
-            task.setTaskPriority(Integer.parseInt(taskPriority));
+            try {
+                int newTaskPriority = Integer.parseInt(taskPriority);
+                if (newTaskPriority < 1 || newTaskPriority > 5) {
+                    errorMessages.add("Task priority should only be from 1 to 5!");
+                } else {
+                    task.setTaskPriority(newTaskPriority);
+                    successMessages.add("The priority for this task has been set to " + newTaskPriority + "!");
+                }
+            } catch (NumberFormatException e) {
+                errorMessages.add("Input for new task priority is not a number!");
+            }
         }
         String taskDueDate = taskDetails.get(2);
         if (taskDueDate != null) {
-            task.setDueDate(taskDueDate);
+            try {
+                task.setDueDate(dateTimeHelper.formatDate(taskDueDate));
+            } catch (ParseException e) {
+                errorMessages.add("Input for new task due date is invalid! Please input the date in the "
+                        + "form 'dd/mm/yyyy'.");
+            }
         }
         String taskCredit = taskDetails.get(3);
         if (!("-1".equals(taskCredit))) {
-            task.setTaskCredit(Integer.parseInt(taskCredit));
+            try {
+                int newTaskCredit = Integer.parseInt(taskCredit);
+                if (newTaskCredit < 1 || newTaskCredit > 100) {
+                    errorMessages.add("Credits for a task should only be from 1 to 100!");
+                } else {
+                    task.setTaskCredit(newTaskCredit);
+                    successMessages.add("The credit for this task has been set to " + newTaskCredit + "!");
+                }
+            } catch (NumberFormatException e) {
+                errorMessages.add("Input for new task credit is not a number!");
+            }
+
         }
         String taskState = taskDetails.get(4);
         if (!("NONE".equals(taskState))) {
-            task.setTaskState(taskState);
+            String newTaskStateLowerCase = taskState.toLowerCase();
+            if ("open".equals(taskState) || "doing".equals(taskState)
+                    || "done".equals(taskState) || "todo".equals(taskState)) {
+                task.setTaskState(newTaskStateLowerCase);
+                successMessages.add("The state of this task has been set to " + taskState.toUpperCase() + "!");
+            } else {
+                errorMessages.add("There are only 4 possible states of a task: 'open', 'todo', 'doing' and 'done'. "
+                        + "Please give a valid state!");
+            }
         }
+
+        if (successMessages.size() != 0) {
+            messagesForUser.add("Success!");
+            messagesForUser.addAll(successMessages);
+            if (errorMessages.size() != 0) {
+                messagesForUser.add("");
+                messagesForUser.add("Errors...");
+                messagesForUser.addAll(errorMessages);
+            }
+        } else {
+            messagesForUser.add("Errors...");
+            messagesForUser.addAll(errorMessages);
+        }
+
+        return messagesForUser.toArray(new String[0]);
     }
 
     public int getSize() {

--- a/src/main/java/util/CommandHelper.java
+++ b/src/main/java/util/CommandHelper.java
@@ -62,7 +62,8 @@ public class CommandHelper {
         helpList.add("");
         helpList.add(" - view task requirements TASK_INDEX");
         helpList.add("");
-        helpList.add(" - edit task requirements TASK_INDEX [-r TASK_REQUIREMENT] [-rm TASK_INDEXES_TO_BE_REMOVED");
+        helpList.add(" - edit task requirements TASK_INDEX [-r TASK_REQUIREMENT] "
+                + "[-rm TASK_REQUIREMENT_INDEXES_TO_BE_REMOVED]");
         helpList.add("");
 
         helpList.add(" - view assignments /MODIFIER");

--- a/src/main/java/util/ParserHelper.java
+++ b/src/main/java/util/ParserHelper.java
@@ -63,6 +63,7 @@ public class ParserHelper {
      *         credit in index 3, task state in index 4.
      */
     public ArrayList<String> parseTaskDetails(String input) {
+        errorMessages.clear();
         ArrayList<String> newTask = new ArrayList<>();
 
         String newTaskName = "--";
@@ -72,30 +73,45 @@ public class ParserHelper {
         String newTaskState = "NONE";
 
         String [] newTaskDetails = input.split("-");
-        ArrayList<String> newTaskDetailsA  =  new ArrayList<>(Arrays.asList(newTaskDetails));
-        newTaskDetailsA.remove(0);
-        for (String s : newTaskDetailsA) {
-            switch (s.charAt(0)) {
-            case 't':
-                newTaskName = s.substring(1).trim();
-                break;
-            case 'p':
-                newTaskPriority = s.substring(1).trim();
-                break;
-            case 'd':
-                newTaskDate = s.substring(1).trim();
-                break;
-            case 'c':
-                newTaskCredit = s.substring(1).trim();
-                break;
-            case 's':
-                newTaskState = s.substring(1).trim();
-                break;
-            default:
-                break;
+        if (newTaskDetails.length == 0) {
+            errorMessages.add("Please input a complete flag! Examples for valid flags include '-t', '-p', '-d', "
+                    + "'-c' and '-s'. Refer to the user guide for more help!");
+        } else {
+            ArrayList<String> newTaskDetailsA = new ArrayList<>(Arrays.asList(newTaskDetails));
+            newTaskDetailsA.remove(0);
+            for (String s : newTaskDetailsA) {
+                String trimmedString = s.trim();
+                if (trimmedString.length() < 2) {
+                    if ("t".equals(trimmedString) || "p".equals(trimmedString) || "d".equals(trimmedString)
+                            || "c".equals(trimmedString) || "s".equals(trimmedString)) {
+                        errorMessages.add("'-" + trimmedString + "' is an empty flag!");
+                    } else {
+                        errorMessages.add("'An invalid flag is used here: -" + trimmedString);
+                    }
+                    continue;
+                }
+                switch (trimmedString.substring(0, 2)) {
+                case "t ":
+                    newTaskName = trimmedString.substring(2);
+                    break;
+                case "p ":
+                    newTaskPriority = trimmedString.substring(2);
+                    break;
+                case "d ":
+                    newTaskDate = trimmedString.substring(2);
+                    break;
+                case "c ":
+                    newTaskCredit = trimmedString.substring(2);
+                    break;
+                case "s ":
+                    newTaskState = trimmedString.substring(2);
+                    break;
+                default:
+                    errorMessages.add("An invalid flag is used here: -" + trimmedString);
+                    break;
+                }
             }
         }
-
         newTask.add(newTaskName);
         newTask.add(newTaskPriority);
         newTask.add(newTaskDate);

--- a/src/main/java/util/ParserHelper.java
+++ b/src/main/java/util/ParserHelper.java
@@ -164,30 +164,35 @@ public class ParserHelper {
         errorMessages.clear();
 
         String[] newTaskRequirementsArray = input.split("-");
-        ArrayList<String> newTaskRequirementsArrayList = new ArrayList<>(Arrays.asList(newTaskRequirementsArray));
-        newTaskRequirementsArrayList.remove(0);
-        for (String s : newTaskRequirementsArrayList) {
-            String trimmedString = s.trim();
-            if (trimmedString.length() <= 2) {
-                if ("r".equals(trimmedString) || "rm".equals(trimmedString)) {
-                    errorMessages.add("There is an empty flag '-" + trimmedString + "'");
-                } else {
-                    errorMessages.add("'-" + trimmedString + "' is an invalid flag");
+        if (newTaskRequirementsArray.length == 0) {
+            errorMessages.add("Please input a complete flag! Examples for valid flags include '-r' and '-rm'."
+                    + " Refer to the user guide for more help!");
+        } else {
+            ArrayList<String> newTaskRequirementsArrayList = new ArrayList<>(Arrays.asList(newTaskRequirementsArray));
+            newTaskRequirementsArrayList.remove(0);
+            for (String s : newTaskRequirementsArrayList) {
+                String trimmedString = s.trim();
+                if (trimmedString.length() <= 2) {
+                    if ("r".equals(trimmedString) || "rm".equals(trimmedString)) {
+                        errorMessages.add("There is an empty flag '-" + trimmedString + "'");
+                    } else {
+                        errorMessages.add("'-" + trimmedString + "' is an invalid flag");
+                    }
+                    continue;
                 }
-                continue;
-            }
 
-            switch (trimmedString.split(" ")[0]) {
-            case "rm":
-                String[] splitTrimmedString = trimmedString.substring(3).split(" ");
-                taskReqIndexesToBeRemoved.addAll(Arrays.asList(splitTrimmedString));
-                break;
-            case "r":
-                taskRequirementsToBeAdded.add(trimmedString.substring(2));
-                break;
-            default:
-                errorMessages.add("Invalid flag is used in this entry: -" + trimmedString);
-                break;
+                switch (trimmedString.split(" ")[0]) {
+                case "rm":
+                    String[] splitTrimmedString = trimmedString.substring(3).split(" ");
+                    taskReqIndexesToBeRemoved.addAll(Arrays.asList(splitTrimmedString));
+                    break;
+                case "r":
+                    taskRequirementsToBeAdded.add(trimmedString.substring(2));
+                    break;
+                default:
+                    errorMessages.add("Invalid flag is used in this entry: -" + trimmedString);
+                    break;
+                }
             }
         }
 

--- a/src/test/java/controllers/ProjectInputControllerTest.java
+++ b/src/test/java/controllers/ProjectInputControllerTest.java
@@ -297,6 +297,7 @@ class ProjectInputControllerTest {
             assertEquals(expectedOutput,actualOutput);
 
             simulatedUserInput = "edit task 1 -c 70 -s doing -p 6 -d 12/12/2020 -t End Game";
+            //6 is an invalid value for task priority, so priority remains as 2 after this command
             dueDate = dateTimeHelper.formatDate("12/12/2020");
             projectInputController.projectEditTask(project,simulatedUserInput);
             actualOutput = "";
@@ -304,7 +305,7 @@ class ProjectInputControllerTest {
                     project.getTasksAndAssignedMembers()).toArray(new String[0])) {
                 actualOutput += message;
             }
-            expectedOutput = "1. End Game | Priority: 6 | Due: 12 Dec 2020"
+            expectedOutput = "1. End Game | Priority: 2 | Due: 12 Dec 2020"
                     + dateTimeHelper.getDifferenceDays(dueDate)
                     + " | Credit: 70 | State: DOING";
             assertEquals(expectedOutput,actualOutput);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42381169/68136393-27baaf00-ff60-11e9-8f73-4ac8227198eb.png)
![image](https://user-images.githubusercontent.com/42381169/68136434-3acd7f00-ff60-11e9-8e7a-6a151f7252fe.png)
![image](https://user-images.githubusercontent.com/42381169/68136518-5c2e6b00-ff60-11e9-95c9-e84d75aad260.png)

`edit task` now able to:
Restrict task priority to 1 - 5
Restrict date input to dd/mm/yyyy
Restrict task credit to 1 - 100
Restrict task state to only the 4 possible states
Account for incomplete flags
Account for wrong flags
Account for missing task index
Account for invalid task index

`edit task` and `edit task requirements` now both able to:
Account for special case of '`edit task 1 -`' or '`edit task requirements 1 -`'

Resolve #309 
Resolve #307 
Resolve #305 
Resolve #304 
Resolve #291 
Resolve #290 
Resolve #289 
Resolve #277 
Resolve #276 
Resolve #274 
Resolve #262 
Resolve #254 
Resolve #253 
Resolve #252 
Resolve #243 